### PR TITLE
Add theme toggle with light mode support

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,10 @@
   <img class="icon on" src="img/windowed.png">
 </a>
 
+<a href="javascript:void(0)" id="themeToggle">
+  <span class="icon">☀</span>
+</a>
+
 <a href="javascript:void(0)" id="sceneListToggle">
   <img class="icon off" src="img/expand.png">
   <img class="icon on" src="img/collapse.png">

--- a/index.js
+++ b/index.js
@@ -29,6 +29,8 @@
   var sceneListToggleElement = document.querySelector('#sceneListToggle');
   var autorotateToggleElement = document.querySelector('#autorotateToggle');
   var fullscreenToggleElement = document.querySelector('#fullscreenToggle');
+  var themeToggleElement = document.querySelector('#themeToggle');
+  var themeIconElement = themeToggleElement.querySelector('.icon');
 
   // Detect desktop or mobile mode.
   if (window.matchMedia) {
@@ -136,6 +138,19 @@
   } else {
     document.body.classList.add('fullscreen-disabled');
   }
+
+  // Set up theme from storage
+  var storedTheme = window.localStorage.getItem('theme');
+  if (storedTheme === 'light') {
+    document.body.classList.add('light-mode');
+  }
+  updateThemeIcon();
+  themeToggleElement.addEventListener('click', function() {
+    document.body.classList.toggle('light-mode');
+    var theme = document.body.classList.contains('light-mode') ? 'light' : 'dark';
+    window.localStorage.setItem('theme', theme);
+    updateThemeIcon();
+  });
 
   // Set handler for scene list toggle.
   sceneListToggleElement.addEventListener('click', toggleSceneList);
@@ -384,6 +399,14 @@
       }
     }
     return null;
+  }
+
+  function updateThemeIcon() {
+    if (document.body.classList.contains('light-mode')) {
+      themeIconElement.textContent = '🌙';
+    } else {
+      themeIconElement.textContent = '☀';
+    }
   }
 
   // Display the initial scene.

--- a/style.css
+++ b/style.css
@@ -16,6 +16,22 @@
   -webkit-tap-highlight-color: rgba(0,0,0,0);
 }
 
+:root {
+  --bg-color: #000;
+  --text-color: #fff;
+  --bar-bg: rgba(58,68,84,0.8);
+  --btn-bg: rgba(103,115,131,0.8);
+  --close-bg: rgba(78,88,104,0.8);
+}
+
+body.light-mode {
+  --bg-color: #fff;
+  --text-color: #000;
+  --bar-bg: rgba(240,240,240,0.8);
+  --btn-bg: rgba(200,200,200,0.8);
+  --close-bg: rgba(220,220,220,0.8);
+}
+
 html, body {
   width: 100%;
   height: 100%;
@@ -24,8 +40,8 @@ html, body {
   overflow: hidden;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 16px;
-  background-color: #000;
-  color: #fff;
+  background-color: var(--bg-color);
+  color: var(--text-color);
 }
 
 a, a:hover, a:active, a:visited {
@@ -58,11 +74,11 @@ a, a:hover, a:active, a:visited {
 
 /* If there is a fullscreen button the title bar must make space for it */
 body.fullscreen-enabled #titleBar {
-  right: 80px;
+  right: 120px;
 }
 
 body.fullscreen-enabled.mobile #titleBar {
-  right: 100px;
+  right: 150px;
 }
 
 /* If there are multiple scenes the title bar must make space for the scene list toggle */
@@ -79,8 +95,7 @@ body.multiple-scenes.mobile #titleBar {
   height: 100%;
   line-height: 30px;
   padding: 5px;
-  background-color: rgb(218, 83, 83);
-  background-color: rgba(58,68,84,0.8);
+  background-color: var(--bar-bg);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -103,8 +118,7 @@ body.multiple-scenes.mobile #titleBar {
   width: 40px;
   height: 40px;
   padding: 5px;
-  background-color: rgb(103,115,131);
-  background-color: rgba(103,115,131,0.8);
+  background-color: var(--btn-bg);
 }
 
 .mobile #fullscreenToggle {
@@ -153,8 +167,7 @@ body.fullscreen-enabled #fullscreenToggle {
   width: 40px;
   height: 40px;
   padding: 5px;
-  background-color: rgb(103,115,131);
-  background-color: rgba(103,115,131,0.8);
+  background-color: var(--btn-bg);
 }
 
 .mobile #autorotateToggle {
@@ -169,6 +182,41 @@ body.fullscreen-enabled #autorotateToggle {
 
 body.fullscreen-enabled.mobile #autorotateToggle {
   right: 50px;
+}
+
+#themeToggle {
+  display: block;
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 40px;
+  height: 40px;
+  padding: 5px;
+  background-color: var(--btn-bg);
+}
+
+.mobile #themeToggle {
+  width: 50px;
+  height: 50px;
+}
+
+body.fullscreen-enabled #themeToggle {
+  right: 80px;
+}
+
+body.fullscreen-enabled.mobile #themeToggle {
+  right: 100px;
+}
+
+#themeToggle .icon {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  width: 30px;
+  height: 30px;
+  font-size: 20px;
+  line-height: 30px;
+  text-align: center;
 }
 
 #autorotateToggle .icon {
@@ -207,8 +255,7 @@ body.fullscreen-enabled.mobile #autorotateToggle {
   width: 40px;
   height: 40px;
   padding: 5px;
-  background-color: rgb(103,115,131);
-  background-color: rgba(103,115,131,0.8);
+  background-color: var(--btn-bg);
 }
 
 .mobile #sceneListToggle {
@@ -273,8 +320,7 @@ body.fullscreen-enabled.mobile #autorotateToggle {
 
 #sceneList .scenes {
   width: 100%;
-  background-color: rgb(58,68,84);
-  background-color: rgba(58,68,84,0.8);
+  background-color: var(--bar-bg);
 }
 
 .mobile #sceneList {
@@ -320,13 +366,11 @@ body.fullscreen-enabled.mobile #autorotateToggle {
 }
 
 .no-touch #sceneList .scene:hover {
-  background-color: rgb(103,115,131);
-  background-color: rgba(103,115,131,0.8);
+  background-color: var(--btn-bg);
 }
 
 #sceneList .scene.current {
-  background-color: rgb(103,115,131);
-  background-color: rgba(103,115,131,0.8);
+  background-color: var(--btn-bg);
 }
 
 /* Hide scene list when only a single scene exists */
@@ -376,8 +420,7 @@ body.single-scene #sceneList, body.single-scene #sceneListToggle {
 
   border-radius: 5px;
 
-  background-color: rgb(58,68,84);
-  background-color: rgba(58,68,84,0.8);
+  background-color: var(--bar-bg);
 
   color: #fff;
 
@@ -453,7 +496,7 @@ body.single-scene #sceneList, body.single-scene #sceneListToggle {
   width: 40px;
   height: 40px;
   border-radius: 20px;
-  background-color: rgb(103,115,131);
+  background-color: var(--btn-bg);
   cursor: pointer;
   -webkit-transition: width 0.3s ease-in-out 0.5s,
                       border-radius 0.3s ease-in-out 0.5s;
@@ -553,7 +596,7 @@ body.single-scene #sceneList, body.single-scene #sceneListToggle {
   height: 40px;
   width: 40px;
   border-top-right-radius: 5px;
-  background-color: rgb(78,88,104);
+  background-color: var(--close-bg);
   visibility: hidden;
   -ms-transform: perspective(200px) rotateY(90deg);
   -webkit-transform: perspective(200px) rotateY(90deg);
@@ -600,7 +643,7 @@ body.single-scene #sceneList, body.single-scene #sceneListToggle {
   top: 40px;
   left: 0;
   padding: 10px;
-  background-color: rgb(58,68,84);
+  background-color: var(--bar-bg);
   border-bottom-right-radius: 5px;
   border-bottom-left-radius: 5px;
   overflow-y: auto;
@@ -682,8 +725,7 @@ body.single-scene #sceneList, body.single-scene #sceneListToggle {
   right: 10px;
   width: auto;
   height: 50px;
-  background-color: rgb(103,115,131);
-  background-color: rgba(103,115,131,0.8);
+  background-color: var(--btn-bg);
   opacity: 0;
   -webkit-transition: opacity 0.3s ease-in-out 0.2s;
   transition: opacity 0.3s ease-in-out 0.2s;
@@ -739,8 +781,7 @@ body.single-scene #sceneList, body.single-scene #sceneListToggle {
   right: 0;
   width: 50px;
   height: 50px;
-  background-color: rgb(78,88,104);
-  background-color: rgba(78,88,104,0.8);
+  background-color: var(--close-bg);
   cursor: pointer;
 }
 
@@ -757,8 +798,7 @@ body.single-scene #sceneList, body.single-scene #sceneListToggle {
   left: 10px;
   right: 10px;
   padding: 10px;
-  background-color: rgb(58,68,84);
-  background-color: rgba(58,68,84,0.8);
+  background-color: var(--bar-bg);
   overflow-y: auto;
   opacity: 0;
   -webkit-transition: opacity 0.3s ease-in-out;
@@ -786,8 +826,7 @@ body.single-scene #sceneList, body.single-scene #sceneListToggle {
   width: 40px;
   height: 40px;
   padding: 5px;
-  background-color: rgb(103,115,131);
-  background-color: rgba(103,115,131,0.8);
+  background-color: var(--btn-bg);
 }
 
 body.view-control-buttons .viewControlButton {


### PR DESCRIPTION
## Summary
- add a simple theme toggle button
- introduce light-mode styles via CSS variables
- persist chosen theme with LocalStorage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685471c2d73c83279dcf9bc0354cf5ad